### PR TITLE
GeneNet ggm.estimate.pcor function wrong argument

### DIFF
--- a/R/GeneNet.wrap.R
+++ b/R/GeneNet.wrap.R
@@ -2,7 +2,7 @@ GeneNet.wrap <- function(data){
     # method <- "static"
     # p <- 0.8
     ngenes <- dim(data)[2]
-    pcor <- GeneNet::ggm.estimate.pcor(t(data),
+    pcor <- GeneNet::ggm.estimate.pcor(data,
                                        method ="static",verbose=FALSE)
     C <- fdrtool::fdrtool(corpcor::sm2vec(pcor),plot=FALSE,
                           statistic="correlation",verbose=FALSE)$param


### PR DESCRIPTION
The problem is described here:
https://support.bioconductor.org/p/104582/

I was able to reproduce, just copy-pasted from GeneNet.wrap:

```
library(netbenchmark)

data <- syntren300.data

ngenes <- dim(data)[2]
pcor <- GeneNet::ggm.estimate.pcor(t(data),
                                   method ="static",verbose=FALSE)
# Doesn't match
print(ncol(pcor))
print(ngenes)
C <- fdrtool::fdrtool(corpcor::sm2vec(pcor),plot=FALSE,
                      statistic="correlation",verbose=FALSE)$param
test.results <- GeneNet::network.test.edges(pcor,plot=FALSE,verbose=FALSE)
crop <- GeneNet::extract.network(test.results,cutoff.ggm=C[1,"cutoff"],
                                 verbose=FALSE)
if(dim(crop)[1]==0){
  d <- round(dim(test.results)[1]/10)
  crop <- GeneNet::extract.network(test.results, 
                                   method.ggm="number", cutoff.ggm=d,
                                   verbose=FALSE)
}
aux <- GeneNet::network.make.graph(crop,node.labels = colnames(data))
net <- as(aux,"matrix")
```

So, _ggm.estimate.pcor_ expects data matrix, where each rows corresponds to one multivariate observation, therefore transposing is wrong, since all the in-house data from _netbenchmark_ have variables in columns.

I'm afraid, the previous results of GeneNet evaluation are wrong, since the error was not triggered as long as input data matrix was squared.

Also _ngenes_ variable is not used, could smth still be missing?
